### PR TITLE
Ajustando bug grafico branco não estava rederizando

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,7 @@ import PDFReport from "./components/PDFReport.tsx";
 import * as htmlToImage from "html-to-image";
 
 function App() {
- const chartRef = useRef<HTMLDivElement>(null);
+  const chartRef = useRef<HTMLDivElement>(null);
   const [ImageData, setImageData] = useState<string | null>(null);
 
   const gerarImagem = async () => {
@@ -16,9 +16,14 @@ function App() {
   };
 
   useEffect(() => {
-    gerarImagem();
-  }, []);
+    // Aguarda 500ms para garantir que o gráfico foi renderizado
+    const timeout = setTimeout(() => {
+      gerarImagem();
+    }, 500);
 
+    return () => clearTimeout(timeout);
+  }, []);
+  
   return (
     <div>
       <h2>Visualização</h2>


### PR DESCRIPTION
## Summary by Sourcery

Delay chart image generation to ensure the graphic has rendered and prevent blank output, and clean up the timeout on unmount.

Bug Fixes:
- Delay image generation by 500ms to ensure the chart renders and avoid a blank graphic.

Enhancements:
- Add cleanup of the timeout in useEffect to clear pending image generation on unmount.